### PR TITLE
Add workarounds for libc++ compatibilty

### DIFF
--- a/libsrc/newforms.cc
+++ b/libsrc/newforms.cc
@@ -1336,7 +1336,7 @@ void newforms::createfromolddata()
   ifstream intdatafile(intdataname.str().c_str());
   if(!intdatafile.is_open())
     {
-      cout<<"Unable to open data file "<<intdataname<<" for data input"<<endl;
+      cout<<"Unable to open data file "<<intdataname.str()<<" for data input"<<endl;
       abort();
       return;
     }

--- a/libsrc/timer.cc
+++ b/libsrc/timer.cc
@@ -74,7 +74,7 @@ timer::~timer() {
   // Close file, if ever opened
   // Do not reference s_ _ever_. We do not
   // want to close std::cout nonetheless.
-  if( file_ != NULL ) {
+  if(!!file_) {
     file_.close();
   }
 }
@@ -101,7 +101,7 @@ void timer::stream( string filename ) {
     file_.open(filename.c_str(),ios::out|ios::trunc);
     
     // Check is file successfully opened
-    if( file_ == NULL ) {
+    if(!file_) {
       {
         cout << "File " << filename << " could not be opened ... using stout" << endl;
         s_ = &cout;


### PR DESCRIPTION
The behavior of std::complex on non-builtin types is unspecified by
the standard and hence varies between the standard libraries. This
hacks in a couple of workarounds to make eclib compile with libc++.

I am not at all familiar with any of this code, so while I guessed what needed to be
done, please do take a close look.

FWIW, I did run `make check`, which came up with a couple of failures
```
Running procs checks...
for prog in smattest comptest rattest bigrattest ptest mptest tbessel mvectest mmattest mspace thilbert tp2points tilll vectest1 vectest2 mattest1 mattest2 space1 space2 svectest1 svectest2 tcon2 tlegcert timing threading; do echo "Testing ${prog}..."; ./${prog} < ./in_ntl/${prog}.in > ${prog}.testout 2>/dev/null && diff ${prog}.testout ./out_ntl/${prog}.out || exit $?; done
Running qcurves checks...
Running qrank checks...
Testing smattest...
for prog in tmrank tequiv d2; do echo "Testing ${prog}..."; ./${prog} < ./in_ntl/${prog}.in > ${prog}.testout 2>/dev/null && diff ${prog}.testout ./out_ntl/${prog}.out || exit $?; done
cp ./in_ntl/allgens.268605 .
Running g0n checks...
rm -rf nftmp
Testing tmrank...
for prog in tcurve tpoints theight thtconst tegr telog tdivpol tperiods tsat tsat2 tsat3 conductor tate torsion twist allisog checkgens; do echo "Testing ${prog}..."; ./${prog} < ./in_ntl/${prog}.in > ${prog}.testout 2>/dev/null && diff ${prog}.testout ./out_ntl/${prog}.out || exit $?; done
mkdir nftmp
Testing tcurve...
for prog in modtest homtest hecketest mhcount tmanin nftest oftest tnfd ; do echo "Testing ${prog}..."; ./${prog} < ./in_ntl/${prog}.in > ${prog}.testout 2>/dev/null && diff ${prog}.testout ./out_ntl/${prog}.out || exit $?; done
Testing modtest...
Testing tpoints...
Testing homtest...
Testing comptest...
Testing theight...
5c5
< AGM((3.125,4.25),(1,0)) = (2.07831617217326684,1.5633615899065958201)
---
> AGM((3.125,4.25),(1,0)) = (2.07831617217326684,1.56336158990659582)
14c14
< whose cube is    (2.9999999999999999998,3.9999999999999999999)
---
> whose cube is    (2.9999999999999999999,4)
16c16
< whose cube is    (2.9999999999999999997,3.9999999999999999999)
---
> whose cube is    (2.9999999999999999996,3.9999999999999999998)
Makefile:1283: recipe for target 'check_procs' failed
make[2]: *** [check_procs] Error 1
make[2]: *** Waiting for unfinished jobs....
Testing hecketest...
Testing mhcount...
Testing thtconst...
Testing tmanin...
3c3
< egr bound = 6.95325e-310
---
> egr bound = 0
Makefile:1288: recipe for target 'check_qcurves' failed
make[2]: *** [check_qcurves] Error 1
/bin/sh: line 1: 66874 Segmentation fault: 11  ./${prog} < ./in_ntl/${prog}.in > ${prog}.testout 2> /dev/null
Makefile:1306: recipe for target 'check_g0n' failed
make[2]: *** [check_g0n] Error 139
23,27c23
< Curve [0,0,0,-532,-4374] :
<
< !!! Fatal error in mwrank: n3 =6 not a power of 2
< This is a bug: please report!
< Failed to compute rank
---
> Curve [0,0,0,-532,-4374] :	Rank = 1
Makefile:1295: recipe for target 'check_qrank' failed
make[2]: *** [check_qrank] Error 1
make[2]: Leaving directory '/Users/kfischer/Projects/eclib/tests'
Makefile:1313: recipe for target 'check' failed
make[1]: *** [check] Error 2
make[1]: Leaving directory '/Users/kfischer/Projects/eclib/tests'
Makefile:404: recipe for target 'check-recursive' failed
make: *** [check-recursive] Error 1
```