### PR TITLE
Be compatible with C++98, C++11, and C++14.

### DIFF
--- a/libsrc/newforms.cc
+++ b/libsrc/newforms.cc
@@ -1336,7 +1336,7 @@ void newforms::createfromolddata()
   ifstream intdatafile(intdataname.str().c_str());
   if(!intdatafile.is_open())
     {
-      cout<<"Unable to open data file "<<intdataname<<" for data input"<<endl;
+      cout<<"Unable to open data file "<<intdataname.str()<<" for data input"<<endl;
       abort();
       return;
     }

--- a/libsrc/timer.cc
+++ b/libsrc/timer.cc
@@ -74,7 +74,7 @@ timer::~timer() {
   // Close file, if ever opened
   // Do not reference s_ _ever_. We do not
   // want to close std::cout nonetheless.
-  if( file_ != NULL ) {
+  if( file_.is_open() ) {
     file_.close();
   }
 }
@@ -101,15 +101,13 @@ void timer::stream( string filename ) {
     file_.open(filename.c_str(),ios::out|ios::trunc);
     
     // Check is file successfully opened
-    if( file_ == NULL ) {
-      {
-        cout << "File " << filename << " could not be opened ... using stout" << endl;
-        s_ = &cout;
-      }
+    if( !file_.is_open() ) {
+      cout << "File " << filename << " could not be opened ... using stout" << endl;
+      s_ = &cout;
+    } else {
+      // Point main reference to newly opened file
+      s_ = &file_;
     }
-
-    // Point main reference to newly opened file
-    s_ = &file_;
   }
 }
 


### PR DESCRIPTION
This fixes the gcc 6 build and also fixes an existing bug in passing.  The code in timer::stream() would set s_ to &cout if the file could not be opened, then immediately overwrite s_ with (unopened) &file_.