### PR TITLE
Define isinf(RR) in NTL namespace

### DIFF
--- a/libsrc/eclib/interface.h
+++ b/libsrc/eclib/interface.h
@@ -161,8 +161,7 @@ inline int is_approx_zero(const RR& x)
 }
 } // namespace NTL
 #ifdef _LIBCPP_VERSION
-namespace std {
-inline namespace __1 {
+namespace NTL {
 inline bool isinf(const RR& z) {
   return false;
 }
@@ -182,8 +181,7 @@ inline RR fmax(const RR& x, const RR& y)
 {
   return x < y ? y : x;
 }
-}
-}
+} // namespace NTL
 #endif
 
 #include <complex>


### PR DESCRIPTION
C++ headers are written such that ADL can be used and `isinf(RR)` defined in NTL namespace is found in the <complex> algorithms.
For some C++ compilers if ADL is not used, `isinf` has to be defined before the <complex> header is used which means the users have to be careful when including this header. ADL is much simpler and less hacky.