### PR TITLE
Avoid name clash with iszero macro in math.h.

### DIFF
--- a/libsrc/eclib/points.h
+++ b/libsrc/eclib/points.h
@@ -29,6 +29,8 @@
 
 #include "curve.h"
 
+#undef iszero
+
 //
 // class for  points on elliptic curves
 //


### PR DESCRIPTION
TS 18661-1 [1][2] introduced a macro named iszero, which is already present in math.h in recent versions of glibc. Since it is a macro, the definition and uses of eclib's iszero method in its Point class are expanded, leading to compilation failure. This patch ensures the macro is not defined where it will cause trouble.

References:
[1] https://www.iso.org/standard/63146.html
[2] A draft version can be read here: http://www.open-std.org/JTC1/sc22/wg14/www/docs/n1778.pdf