### PR TITLE
Fix out-of-bounds vector accesses.

### DIFF
--- a/libsrc/symb.cc
+++ b/libsrc/symb.cc
@@ -154,7 +154,8 @@ symbdata::symbdata(long n) :moddata(n),specials(nsymb2)
 //N.B. dlist include d=1 at 0 and d=mod at end, which we don't want here
    for (ic=1; (ic<ndivs-1)&&(specials.count()<nsymb2); ic++)
    { c=dlist[ic];
-     dstarts[ic]=start=specials.count();
+     start=specials.count();
+     dstarts.assign(ic,start);
      for (id=1; (id<modulus-phi)&&(specials.count()<nsymb2); id++)  
      { d = noninvlist[id];
        if (::gcd(d,c)==1)
@@ -184,7 +185,8 @@ long symbdata::index2(long c, long d) const
        return   modulus-code(xmodmul(kc,d,modulus));
     else
     {
-     long start = dstarts[noninvdlist[-kc]];
+     long indx = noninvdlist[-kc];
+     long start = (indx < dstarts.size()) ? dstarts[indx] : 0;
      symb s(c,d,this);
      long ind = specials.index(s,start);
      if(ind<0) 


### PR DESCRIPTION
The Fedora project recently added -D_GLIBCXX_ASSERTIONS to the build flags.  With recent versions of glibc, this activates runtime assertions in the C++ library.  Building the eclib package with the assertions activated revealed two places in the code where an out-of-bounds vector index is accessed, both in libsrc/symb.cc.  You may well want to address the issue in some other way than the approach I took with this pull request, but it at least shows you where in the code these accesses are happening.

In the first case, on line 157, a vector element is assigned to, but may not exist already.  The assign method both does the assignment and increases the size of the vector so that the vector is valid.

In the second case, on line 187, the value of noninvdlist[-kc] can be larger than the size of the dstarts array; I chose to set start to zero.

The testsuite runs successfully with these two changes.