### PR TITLE
make  with-flint="" consistent with ntl and pari

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_ARG_WITH(flint,
   [  
     if test "$withval" = "no"; then
        want_flint=no
-    elif test "$withval" = "yes"; then
+    elif test "$withval" = "yes" -o "$withval" = ""; then
         want_flint=yes
         AC_CHECK_LIB([flint], [fmpz_init, nmod_mat_rref],
         [FLINT_CFLAGS="-DFLINT_LEVEL=1";


### PR DESCRIPTION
 `--with-flint=""` does not do the same as `--with-flint=yes`, it does add `-L/lib` to LDFLAGS, with
sometimes disasterous results, cf. https://trac.sagemath.org/ticket/28401, whereas 
`--with-ntl=""` and `--with-pari=""` treat `""` as `yes`.