### PR TITLE
basic pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ syntax: glob
 configure
 Makefile
 Makefile.in
+eclib.pc
 */Makefile
 */Makefile.in
 autom4te.cache

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,4 @@
 ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = libsrc tests progs doc man
+pkgconfigdir       = $(libdir)/pkgconfig
+pkgconfig_DATA     = eclib.pc

--- a/configure.ac
+++ b/configure.ac
@@ -238,5 +238,6 @@ AC_CONFIG_FILES([
   doc/Makefile
   man/Makefile
   Makefile
+  eclib.pc
 ])
 AC_OUTPUT

--- a/eclib.pc.in
+++ b/eclib.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@prefix@/include
+
+Name: @PACKAGE_NAME@
+Description: C++ code for computations with elliptic curves, including mwrank, etc.
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lec
+Cflags: -I${includedir}


### PR DESCRIPTION
may be improved by working out flags for the dependencies
but for the purposed of getting the version this does
the job.