### PR TITLE
Fix binder postBuild script

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -7,6 +7,7 @@ export PREFIX=$CONDA_DIR
 # For now, we need an alpha version of JupyterLab. Can be removed later.
 pip install --pre -U jupyterlab
 
+echo "configuring eclib with PREFIX=$PREFIX"
 
 # Configure eclib with autotools
 export CONFIGURE_OPTS="--disable-mpfp"

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -14,6 +14,11 @@ export CONFIGURE_OPTS="--disable-mpfp"
 export CPPFLAGS="-I$PREFIX/include $CPPFLAGS"
 export LDFLAGS="-L$PREFIX/lib -Wl,-rpath,$PREFIX/lib $LDFLAGS"
 
+echo "environment"
+echo "==========="
+env | sort
+echo
+
 chmod +x autogen.sh
 ./autogen.sh
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,7 +2,7 @@
 
 # Our conda env has the necessary dependencies, so propagate them
 # for the build below
-export PREFIX=$CONDA_DIR
+export PREFIX="$CONDA_DEFAULT_ENV"
 
 # For now, we need an alpha version of JupyterLab. Can be removed later.
 pip install --pre -U jupyterlab


### PR DESCRIPTION
Follow-up to #59; this fixes the build for binder for me.

In the future it might make sense to provide a custom Dockerfile in which to perform the build; since it's done in the "postBuild" script it means we have to compile eclib every time a binder is launched which takes quite some time.