### PR TITLE
Fix log(CC) with libc++ >=16

### DIFF
--- a/libsrc/eclib/interface.h
+++ b/libsrc/eclib/interface.h
@@ -203,6 +203,11 @@ template <> inline CC std::exp(const CC &z)
   RR e = exp(z.real());
   return CC(e * cos(im), e * sin(im));
 }
+template <> inline CC std::log(const CC &z)
+{
+  RR arg = atan2(z.imag(), z.real());
+  return CC(log(std::abs(z)), arg);
+}
 inline CC operator/(const CC &a, const CC &b)
 {
   RR are = a.real();


### PR DESCRIPTION
libc++ 16 changed the definition of log(complex<T> x) from
```
  complex<T>(log(abs(x)), arg(x));
```
to
```
  complex<T>(std::log(std::abs(x)), std::arg(x));
```
which means argument dependent lookup (ADL) does not work anymore. Defining CC = std::complex<RR> is undefined behaviour anyway according to the C++ standard. So, the change in libc++ is technically not a backwards incompatible change.