### PR TITLE
bump checkouts' version

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,7 +17,7 @@ jobs:
         mpfp: [enable-mpfp, disable-mpfp]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: configure
       run: |
         sudo apt-get install libpari-dev pari-gp2c libntl-dev libflint-dev

--- a/.github/workflows/conda-c-cpp.yml
+++ b/.github/workflows/conda-c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
         mpfp: [enable-mpfp, disable-mpfp]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v2
       with:
         miniforge-version: latest


### PR DESCRIPTION
gets rid of node12 warnings from GH