### PR TITLE
missing include with recent FLINT

### DIFF
--- a/libsrc/eclib/flinterface.h
+++ b/libsrc/eclib/flinterface.h
@@ -37,6 +37,7 @@
 
 //#define TRACE_FLINT_RREF
 
+#include <gmp.h>
 #include <flint/flint.h> // must include this first to set __FLINT_VERSION
 
 #if (__FLINT_VERSION>2)


### PR DESCRIPTION
As of FLINT cb7513b59d050cd2939c631533fb1f1ebae81508, the #include
directives already present are not enough to define mp_limb_t.
