### PR TITLE
Fix crashes with flint 3.3

### DIFF
--- a/libsrc/eclib/flinterface.h
+++ b/libsrc/eclib/flinterface.h
@@ -58,14 +58,22 @@ typedef struct
     hlimb_t * entries;
     slong r;
     slong c;
+#if (__FLINT_VERSION==3)&&(__FLINT_VERSION_MINOR<3)
     hlimb_t ** rows;
+#else
+    slong stride;
+#endif
     nmod_t mod;
 }
 hmod_mat_struct;
 
 typedef hmod_mat_struct hmod_mat_t[1];
 
+#if (__FLINT_VERSION==3)&&(__FLINT_VERSION_MINOR<3)
 #define hmod_mat_entry(mat,i,j) ((mat)->rows[(i)][(j)])
+#else
+#define hmod_mat_entry nmod_mat_entry
+#endif
 #define hmod_mat_nrows(mat) ((mat)->r)
 #define hmod_mat_ncols(mat) ((mat)->c)
 

--- a/libsrc/mat.cc
+++ b/libsrc/mat.cc
@@ -1602,7 +1602,9 @@ hmod_mat_clear(hmod_mat_t mat)
   if (mat->entries)
     {
       flint_free(mat->entries);
+#if (__FLINT_VERSION==3)&&(__FLINT_VERSION_MINOR<3)
       flint_free(mat->rows);
+#endif
     }
 }
 


### PR DESCRIPTION
In flint 3.3, gr_mat_struct replaced the `rows` array with row stride [1], update hmod_mat_struct accordingly.

Also, in that case we can use upstream's nmod_mat_entry macro, which doesn't do any type checking.

Fixes https://github.com/JohnCremona/eclib/issues/86

[1] https://github.com/flintlib/flint/commit/25251b8b69d109f60162101e6e2194bce19068a5