### PR TITLE
Change make install to sudo make install

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,7 +26,7 @@ jobs:
         cd flint-3.5.0
         ./configure
         make -j 8
-        make install
+        sudo make install
         sudo ldconfig
         cd ..
         ./autogen.sh


### PR DESCRIPTION
that's another one from the prematurely closed PR.
Note that CI runs for at least gcc, and errors as follows:
```
Testing flint_test...flint_test completed
Testing polredtest...polredtest completed
23c23
< A root of f is a = -2*b+1 where g(b)=0
---
> A root of f is a = 2*b-1 where g(b)=0
make[2]: *** [Makefile:1850: check_procs] Error 1
make[2]: Leaving directory '/home/runner/work/eclib/eclib/tests'
make[1]: *** [Makefile:1886: check] Error 2
make[1]: Leaving directory '/home/runner/work/eclib/eclib/tests'
make: *** [Makefile:463: check-recursive] Error 1
```

(too tight a test, assuming root ordering?)

